### PR TITLE
feat: respect .prettierignore

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,9 +108,23 @@ for `tslint@^5.0.0`
   {
     "extends": ["tslint-plugin-prettier"],
     "rules": {
-      "prettier": [true, { "singleQuote": true }]
+      "prettier": [true, null, { "singleQuote": true }]
     }
   }
+  ```
+
+## Ignoring files
+
+- It will respect your .prettierignore file in your project root but if you would like to use a different file you can provide it in the third argument, for example:
+
+  ```json
+  {
+    "extends": ["tslint-plugin-prettier"],
+    "rules": {
+      "prettier": [true, { "ignorePath": "otherDirectory/.prettierignore" }]
+    }
+  }
+
   ```
 
 ## Development

--- a/README.md
+++ b/README.md
@@ -108,20 +108,20 @@ for `tslint@^5.0.0`
   {
     "extends": ["tslint-plugin-prettier"],
     "rules": {
-      "prettier": [true, null, { "singleQuote": true }]
+      "prettier": [true, { "singleQuote": true }]
     }
   }
   ```
 
 ## Ignoring files
 
-- It will respect your .prettierignore file in your project root but if you would like to use a different file you can provide it in the third argument, for example:
+- It will respect your .prettierignore file in your project root ( process.cwd() ) but if you would like to use a different file you can provide it in the third argument, for example:
 
   ```json
   {
     "extends": ["tslint-plugin-prettier"],
     "rules": {
-      "prettier": [true, { "ignorePath": "otherDirectory/.prettierignore" }]
+      "prettier": [true, null, { "ignorePath": "otherDirectory/.prettierignore" }]
     }
   }
 

--- a/src/prettierRule.ts
+++ b/src/prettierRule.ts
@@ -7,9 +7,20 @@ import * as ts from 'typescript';
 
 export class Rule extends tslint.Rules.AbstractRule {
   public apply(sourceFile: ts.SourceFile): tslint.RuleFailure[] {
+    if (this.sourceFileIsIgnored(sourceFile, this.ruleArguments)) {
+      return [];
+    }
     return this.applyWithWalker(
       new Walker(sourceFile, this.ruleName, this.ruleArguments),
     );
+  }
+  private sourceFileIsIgnored(sf: ts.SourceFile, ruleArguments: any[]) {
+    let ignorePath = '.prettierignore';
+    if (ruleArguments.length === 3) {
+      ignorePath = ruleArguments[2];
+    }
+    const r = prettier.getFileInfo.sync(sf!.fileName, { ignorePath });
+    return r.ignored;
   }
 }
 

--- a/src/prettierRule.ts
+++ b/src/prettierRule.ts
@@ -14,13 +14,19 @@ export class Rule extends tslint.Rules.AbstractRule {
       new Walker(sourceFile, this.ruleName, this.ruleArguments),
     );
   }
-  private sourceFileIsIgnored(sf: ts.SourceFile, ruleArguments: any[]) {
+  private getIgnorePath(ruleArguments: any[]) {
     let ignorePath = '.prettierignore';
-    if (ruleArguments.length === 3) {
-      ignorePath = ruleArguments[2];
+    if (ruleArguments.length === 2 && ruleArguments[1].ignorePath) {
+      ignorePath = ruleArguments[1].ignorePath;
     }
-    const r = prettier.getFileInfo.sync(sf!.fileName, { ignorePath });
-    return r.ignored;
+    return ignorePath;
+  }
+  private sourceFileIsIgnored(sourceFile: ts.SourceFile, ruleArguments: any[]) {
+    const ignorePath = this.getIgnorePath(ruleArguments);
+    const fileInfo = prettier.getFileInfo.sync(sourceFile!.fileName, {
+      ignorePath,
+    });
+    return fileInfo.ignored;
   }
 }
 

--- a/tests/prettier/prettier-ignored/.prettierignore
+++ b/tests/prettier/prettier-ignored/.prettierignore
@@ -1,0 +1,1 @@
+prettierIgnoredSyntaxError.ts

--- a/tests/prettier/prettier-ignored/prettierIgnoredSyntaxError.ts.lint
+++ b/tests/prettier/prettier-ignored/prettierIgnoredSyntaxError.ts.lint
@@ -1,0 +1,1 @@
+hello world

--- a/tests/prettier/prettier-ignored/tslint.json
+++ b/tests/prettier/prettier-ignored/tslint.json
@@ -1,0 +1,6 @@
+{
+  "rulesDirectory": ["../../../rules"],
+  "rules": {
+    "prettier": [true, null, null, "tests/prettier/prettier-ignored/.prettierignore"]
+  }
+}

--- a/tests/prettier/prettier-ignored/tslint.json
+++ b/tests/prettier/prettier-ignored/tslint.json
@@ -1,6 +1,6 @@
 {
   "rulesDirectory": ["../../../rules"],
   "rules": {
-    "prettier": [true, null, null, "tests/prettier/prettier-ignored/.prettierignore"]
+    "prettier": [true, null, { "ignorePath": "tests/prettier/prettier-ignored/.prettierignore"}]
   }
 }


### PR DESCRIPTION
Closes #287 

It allows for specifying the ignore-path as a new third option which has been tested.
It defaults to .prettierignore 

```
private sourceFileIsIgnored(sf: ts.SourceFile, ruleArguments: any[]) {
    let ignorePath = '.prettierignore';
    if (ruleArguments.length === 3) {
      ignorePath = ruleArguments[2];
    }
    const r = prettier.getFileInfo.sync(sf!.fileName, { ignorePath });
    return r.ignored;
  }
```

but this cannot be tested without adding a .prettierignore file in the root of the repository or an e2e test. This is due to path.resolve which is not set for tests as it would be when running tslint.

[from prettier](https://github.com/prettier/prettier/blob/f421c7f6133761ad63ae2b86251ebba8e4f0ba7d/src/common/create-ignorer.js#L22)

```
createIgnorer.sync = function(ignorePath, withNodeModules) {
  const ignoreContent = !ignorePath
    ? null
    : getFileContentOrNull.sync(path.resolve(ignorePath));
  return _createIgnorer(ignoreContent, withNodeModules);
};
```

If desired you could have the third argument be the contents of .prettierignore and use the ignorer directly.